### PR TITLE
Fix invalid arguments for location_rpt and bbox.

### DIFF
--- a/silkconfig/conf/schema.xml
+++ b/silkconfig/conf/schema.xml
@@ -420,12 +420,12 @@
       For more information about this and other Spatial fields new to Solr 4, see:
       http://wiki.apache.org/solr/SolrAdaptersForLuceneSpatial4
     -->
-    <fieldType class="solr.SpatialRecursivePrefixTreeFieldType" distErrPct="0.025" geo="true" maxDistErr="0.000009" name="location_rpt" units="degrees"/>
+    <fieldType class="solr.SpatialRecursivePrefixTreeFieldType" distErrPct="0.025" geo="true" maxDistErr="0.000009" name="location_rpt" distanceUnits="degrees"/>
 
     <!-- Spatial rectangle (bounding box) field. It supports most spatial predicates, and has
      special relevancy modes: score=overlapRatio|area|area2D (local-param to the query).  DocValues is required for
      relevancy. -->
-    <fieldType class="solr.BBoxField" geo="true" name="bbox" numberType="_bbox_coord" units="degrees"/>
+    <fieldType class="solr.BBoxField" geo="true" name="bbox" numberType="_bbox_coord" distanceUnits="degrees"/>
     <fieldType class="solr.TrieDoubleField" docValues="true" name="_bbox_coord" precisionStep="8" stored="false"/>
 
 </schema>


### PR DESCRIPTION
Invalid arguments:{units=degrees} occured on Solr 6.0.0.
Please see following messages;

```
org.apache.solr.client.solrj.impl.HttpSolrClient$RemoteSolrException:Error from server at http://localhost:8983/solr: Error CREATEing SolrCore 'silkconfig_shard1_replica1': Unable to create core [silkconfig_shard1_replica1] Caused by: schema fieldtype location_rpt(org.apache.solr.schema.SpatialRecursivePrefixTreeFieldType) invalid arguments:{units=degrees}
```

```
org.apache.solr.client.solrj.impl.HttpSolrClient$RemoteSolrException:Error from server at http://localhost:8983/solr: Error CREATEing SolrCore 'silkconfig_shard1_replica1': Unable to create core [silkconfig_shard1_replica1] Caused by: schema fieldtype bbox(org.apache.solr.schema.BBoxField) invalid arguments:{units=degrees}
```

I changed “units" to “distanceUnits".
